### PR TITLE
Source move fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,8 @@ With C++, the workflow looks like this:
 
 1. Download or clone this repo
 2. Copy everything in `Unity/Assets` directory to your Unity project's `Assets` directory
-3. Copy the `Unity/CppSource` directory to your Unity project directory
-4. Edit `NativeScriptTypes.json` and specify what parts of the Unity, .NET, and custom DLL APIs you want access to from C++.
-5. Edit `Unity/CppSource/Game/Game.cpp` and `Unity/CppSource/Game/Game.h` to create your game. Some example code is provided, but feel free to delete it. You can add more C++ source (`.cpp`) and header (`.h`) files here as your game grows.
+3. Edit `NativeScriptTypes.json` and specify what parts of the Unity, .NET, and custom DLL APIs you want access to from C++.
+4. Edit `Unity/Assets/CppSource/Game/Game.cpp` and `Unity/Assets/CppSource/Game/Game.h` to create your game. Some example code is provided, but feel free to delete it. You can add more C++ source (`.cpp`) and header (`.h`) files here as your game grows.
 
 # Building the C++ Plugin
 

--- a/Unity/Assets/NativeScript/Editor/GenerateBindings.cs
+++ b/Unity/Assets/NativeScript/Editor/GenerateBindings.cs
@@ -24,7 +24,7 @@ namespace NativeScript
 	{
 		// Disable unused field types. JsonUtility actually uses them, but it
 		// does so with reflection.
-		#pragma warning disable CS0649
+		#pragma warning disable 649
 		
 		[Serializable]
 		class JsonConstructor
@@ -289,7 +289,9 @@ namespace NativeScript
 		static readonly string CppDirPath =
 			Path.Combine(
 				Path.Combine(
-					ProjectDirPath,
+					Path.Combine(
+						ProjectDirPath,
+						"Assets"),
 					"CppSource"),
 				"NativeScript");
 		static readonly string CsharpPath = Path.Combine(
@@ -308,7 +310,7 @@ namespace NativeScript
 			= new FieldOrderComparer();
 		
 		// Restore unused field types
-		#pragma warning restore CS0649
+		#pragma warning restore 649
 		
 		public static void Generate()
 		{


### PR DESCRIPTION
Hello ! I noticed when upgrading to the latest version you forgot to modify a file when moving CppSource to the Assets folder, which prevents generating the bindings in Unity. I fixed it, and updated the readme which was also slightly outdated.
I also noticed some `#pragma warning` caused _new_ warnings in Unity 2018, so I changed them too.
It's the first time I make a fork and pull request on Github, I hope I didn't mess things up :P So don't hesitate to tell me if I did something wrong.