### PR TITLE
[#51] Fix performance issue with Object Store

### DIFF
--- a/Unity/Assets/NativeScript/Bindings.cs
+++ b/Unity/Assets/NativeScript/Bindings.cs
@@ -38,6 +38,9 @@ namespace NativeScript
 			public static void Init(int maxObjects)
 			{
 				ObjectStore.maxObjects = maxObjects;
+				handleLookupByHash = new Dictionary<uint, int> ();
+				hashLookupByHandle = new Dictionary<int, uint> ();
+				freeHandleStack = new Stack<int> ();
 				
 				// Initialize the objects as all null plus room for the
 				// first to always be null.

--- a/Unity/Assets/NativeScript/Bindings.cs
+++ b/Unity/Assets/NativeScript/Bindings.cs
@@ -36,7 +36,7 @@ namespace NativeScript
 
 			// Index of the next available handle
 			static int nextHandleIndex;
-			
+
 			// The maximum number of objects to store. Must be positive.
 			static int maxObjects;
 			

--- a/Unity/Assets/NativeScript/Bindings.cs
+++ b/Unity/Assets/NativeScript/Bindings.cs
@@ -40,7 +40,7 @@ namespace NativeScript
 			public static void Init(int maxObjects)
 			{
 				ObjectStore.maxObjects = maxObjects;
-				objectHandleCache = new Dictionary<object, int> (maxObjects);	
+				objectHandleCache = new Dictionary<object, int>(maxObjects);	
 				handles = new Stack<int> (maxObjects);
 				
 				// Initialize the objects as all null plus room for the
@@ -93,8 +93,7 @@ namespace NativeScript
 				
 				lock (objects)
 				{
-					// A handle with a value of 0 is NULL
-					int handle = 0;
+					int handle;
 
 					// Get handle from object cache
 					if (objectHandleCache.TryGetValue(obj, out handle))


### PR DESCRIPTION
When BaseMaxSimultaneous was set to a large number the object-store was
spending to much time finding the handle. This was fixed using a
dictionary where the keys have the objects full hash.