### PR TITLE
Fix for standalone builds defaulting to int parameters

### DIFF
--- a/Unity/Assets/NativeScript/Editor/GenerateBindings.cs
+++ b/Unity/Assets/NativeScript/Editor/GenerateBindings.cs
@@ -10573,18 +10573,21 @@ namespace NativeScript.Editor
 			for (int i = 0; i < parameters.Length; ++i)
 			{
 				ParameterInfo param = parameters[i];
-				if (param.Kind == TypeKind.FullStruct)
+				switch (param.Kind)
 				{
-					AppendCsharpTypeFullName(
-						param.ParameterType,
-						output);
-					output.Append(" param");
-					output.Append(i);
-				}
-				else
-				{
-					output.Append("int param");
-					output.Append(i);
+					case TypeKind.FullStruct:
+					case TypeKind.Primitive:
+					case TypeKind.Enum:
+						AppendCsharpTypeFullName(
+							param.ParameterType,
+							output);
+						output.Append(" param");
+						output.Append(i);
+						break;
+					default:
+						output.Append("int param");
+						output.Append(i);
+						break;
 				}
 				if (i != parameters.Length-1)
 				{


### PR DESCRIPTION
There was a mis-match in how types were specified in editor/build delegates. Changed so they both now use the same switch statement