### PR TITLE
Set abstract base method declarations as virtual

### DIFF
--- a/Unity/Assets/NativeScript/Editor/GenerateBindings.cs
+++ b/Unity/Assets/NativeScript/Editor/GenerateBindings.cs
@@ -3427,7 +3427,15 @@ namespace NativeScript.Editor
 				builders.CsharpFunctions);
 			builders.CsharpFunctions.Append('.');
 			builders.CsharpFunctions.Append(eventName);
-			builders.CsharpFunctions.Append(" += del;");
+			// TODO: More safely differenciate between add/removing event delegates
+			if (funcName.Contains("RemoveEvent"))
+			{
+				builders.CsharpFunctions.Append(" -= del;");
+			}
+			else
+			{
+				builders.CsharpFunctions.Append(" += del;");
+			}
 			AppendCsharpFunctionEnd(
 				typeof(void),
 				null,
@@ -4155,7 +4163,8 @@ namespace NativeScript.Editor
 				AppendCppMethodDeclaration(
 					cppMethodName,
 					enclosingTypeIsStatic,
-					false,
+					// Mark as virtual if method/class is not static or generic
+					cppMethodIsStatic || enclosingTypeIsStatic || methodTypeParams != null? false : true,
 					cppMethodIsStatic,
 					cppReturnType,
 					methodTypeParams,


### PR DESCRIPTION
The codegen would set all abstract base methods to be non-virtual, this allows derived classes to cleanly override abstract function implementations