### PR TITLE
Set abstract base method declarations as virtual

### DIFF
--- a/Unity/Assets/NativeScript/Editor/GenerateBindings.cs
+++ b/Unity/Assets/NativeScript/Editor/GenerateBindings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
@@ -4155,7 +4155,8 @@ namespace NativeScript.Editor
 				AppendCppMethodDeclaration(
 					cppMethodName,
 					enclosingTypeIsStatic,
-					false,
+					// Mark as virtual if method/class is not static or generic
+					cppMethodIsStatic || enclosingTypeIsStatic || methodTypeParams != null? false : true,
 					cppMethodIsStatic,
 					cppReturnType,
 					methodTypeParams,


### PR DESCRIPTION
The codegen would set all abstract base methods to be non-virtual, this allows derived classes to cleanly override abstract function implementations